### PR TITLE
Improve performance and simplify report titles

### DIFF
--- a/zotero_summarizer/extract_html.py
+++ b/zotero_summarizer/extract_html.py
@@ -327,7 +327,7 @@ class ZoteroHTMLExtractor(ZoteroBaseProcessor):
                             else:
                                 errors += 1
 
-                            time.sleep(1)
+                            time.sleep(0.1)
                     else:
                         print("  ✗ Could not fetch content from URL")
                         errors += 1
@@ -394,9 +394,9 @@ class ZoteroHTMLExtractor(ZoteroBaseProcessor):
                         processed += 1
                     else:
                         errors += 1
-                    
+
                     # Rate limiting - be nice to Zotero API
-                    time.sleep(1)
+                    time.sleep(0.1)
                     break  # Process only the first HTML attachment
                 else:
                     print("  ✗ Could not retrieve HTML content")

--- a/zotero_summarizer/summarize_sources.py
+++ b/zotero_summarizer/summarize_sources.py
@@ -345,8 +345,8 @@ class ZoteroSourceSummarizer(ZoteroBaseProcessor):
                 errors += 1
 
             # Rate limiting - be nice to the APIs
-            print(f"  ⏳ Rate limiting (1 second)...")
-            time.sleep(1)
+            print(f"  ⏳ Rate limiting (0.1 second)...")
+            time.sleep(0.1)
 
         # Print summary
         print(f"\n{'='*80}")

--- a/zotero_summarizer/zresearcher.py
+++ b/zotero_summarizer/zresearcher.py
@@ -2413,7 +2413,7 @@ Generated: {datetime.now().strftime("%B %d, %Y at %I:%M %p")}
             note_key = self.create_standalone_note(
                 subcollection_key,
                 stub_content,
-                f"Research Report - {datetime.now().strftime('%Y-%m-%d')}: {report_title} (See File)",
+                f"{report_title} (See File)",
                 convert_markdown=True
             )
 
@@ -2440,13 +2440,11 @@ Generated: {datetime.now().strftime("%B %d, %Y at %I:%M %p")}
         else:
             print(f"  Creating note in {self._get_subcollection_name()}...")
 
-            note_title = f"Research Report - {datetime.now().strftime('%Y-%m-%d')}: {report_title}"
-
             # Create note with HTML content directly (no markdown conversion)
             note_key = self.create_standalone_note(
                 subcollection_key,
                 html_content,
-                note_title,
+                report_title,
                 convert_markdown=False  # Already HTML
             )
 


### PR DESCRIPTION
Two improvements for better user experience:

1. Reduce Zotero API rate limiting from 1.0s to 0.1s
   - Update extract_html.py: Change time.sleep(1) to time.sleep(0.1)
   - Update summarize_sources.py: Change time.sleep(1) to time.sleep(0.1)
   - Significantly faster processing while still being respectful to API

2. Remove redundant date from report titles
   - Update zresearcher.py: Remove date prefix from targeted report titles
   - Before: "Research Report - 2025-11-07: [Title]"
   - After: "[Title]"
   - Zotero automatically adds date stamps to notes, making manual dates redundant
   - Cleaner, more concise titles