### PR TITLE
Add LLM-powered metadata extraction for organize-sources workflow

### DIFF
--- a/src/zr_prompts.py
+++ b/src/zr_prompts.py
@@ -182,3 +182,61 @@ Please provide:
    - Location (page number, section, etc.) if available
 
 Format your response using clear markdown headings and structure."""
+
+
+def metadata_extraction_prompt(
+    content: str,
+    filename: str,
+    content_type: str
+) -> str:
+    """
+    Prompt for extracting metadata from source content.
+
+    Used in organize-sources workflow when creating parent items from attachments.
+    Attempts to extract: Title, Author(s), Publication, Date
+
+    Args:
+        content: Source content (first 10,000 characters)
+        filename: Original filename of the attachment
+        content_type: MIME type of the attachment
+
+    Returns:
+        Formatted prompt string
+    """
+    return f"""You are analyzing a document to extract bibliographic metadata. The document was uploaded as an attachment with the following properties:
+
+Filename: {filename}
+Content Type: {content_type}
+
+Content (first 10,000 characters):
+{content}
+
+Please extract the following metadata from this document:
+
+1. **Title**: The full title of the document
+2. **Authors**: The author(s) of the document (if multiple, separate with commas)
+3. **Publication**: The publication venue (journal, website, publisher, etc.)
+4. **Date**: Publication date or date referenced in the document
+
+Guidelines:
+- If a field cannot be determined from the content, respond with "Unknown"
+- For the title, if no clear title is present, derive a descriptive title from the content
+- For authors, look for bylines, author sections, or signatures
+- For publication, look for journal names, website names, publisher information, or source attribution
+- For dates, look for publication dates, copyright dates, or date stamps (format as YYYY-MM-DD if possible, or YYYY if only year is available)
+
+Format your response EXACTLY as follows:
+
+TITLE:
+<title here>
+
+AUTHORS:
+<authors here>
+
+PUBLICATION:
+<publication here>
+
+DATE:
+<date here>
+
+Provide ONLY the metadata in the format above, nothing else."""


### PR DESCRIPTION
When promote_attachment_to_parent() creates a new parent item from a standalone attachment, it now uses an LLM to extract rich metadata from the attachment content to populate the parent item fields.

Changes:
- Add metadata_extraction_prompt() to zr_prompts.py for LLM metadata extraction
- Add _extract_content_from_attachment() to extract first 10,000 chars from attachments
- Add _parse_metadata_response() to parse LLM metadata extraction responses
- Add _extract_metadata_with_llm() to orchestrate LLM metadata extraction
- Update promote_attachment_to_parent() to use LLM metadata when available
- Populate parent item with: title, authors, publication, and date
- Fallback to simple filename-based extraction if LLM extraction fails

The LLM analyzes the first 10,000 characters of the attachment content to determine:
- Title
- Author(s)
- Publication
- Date

Uses Claude Haiku 4.5 with temperature=0.0 for consistent metadata extraction.