### PR TITLE
Refactor: Add generic note loading/updating methods to zr_common

### DIFF
--- a/src/zr_build.py
+++ b/src/zr_build.py
@@ -35,46 +35,13 @@ class ZoteroResearcherBuilder(ZoteroResearcherBase):
             FileNotFoundError: If subcollection or note not found
             ValueError: If note still contains template placeholder
         """
-        subcollection_name = self._get_subcollection_name()
-        note_title = self._get_project_overview_note_title()
-
-        # Get project-specific subcollection
-        subcollection_key = self.get_subcollection(collection_key, subcollection_name)
-        if not subcollection_key:
-            raise FileNotFoundError(
-                f"{subcollection_name} subcollection not found. "
-                f"Run --init-collection --project \"{self.project_name}\" first."
-            )
-
-        # Get all notes in subcollection
-        notes = self.get_collection_notes(subcollection_key)
-
-        for note in notes:
-            title = self.get_note_title_from_html(note['data']['note'])
-            if note_title in title:
-                content = self.extract_text_from_note_html(note['data']['note'])
-
-                # Check if still template
-                if '[TODO:' in content:
-                    raise ValueError(
-                        f"{note_title} still contains template. "
-                        "Please edit the note in Zotero before building summaries."
-                    )
-
-                # Remove template footer if present
-                if '---' in content:
-                    content = content.split('---')[0]
-
-                # Remove title line
-                lines = content.split('\n')
-                if lines and note_title in lines[0]:
-                    content = '\n'.join(lines[1:])
-
-                return content.strip()
-
-        raise FileNotFoundError(
-            f"{note_title} not found in {subcollection_name} subcollection. "
-            f"Run --init-collection --project \"{self.project_name}\" first."
+        return self.load_note_from_subcollection(
+            collection_key,
+            self._get_project_overview_note_title(),
+            check_todo=True,
+            remove_title_line=True,
+            remove_footer=True,
+            operation_name="building summaries"
         )
 
     def load_tags_from_zotero(self, collection_key: str) -> List[str]:
@@ -91,53 +58,26 @@ class ZoteroResearcherBuilder(ZoteroResearcherBase):
             FileNotFoundError: If subcollection or note not found
             ValueError: If note still contains template placeholder or is empty
         """
-        subcollection_name = self._get_subcollection_name()
         note_title = self._get_research_tags_note_title()
 
-        # Get project-specific subcollection
-        subcollection_key = self.get_subcollection(collection_key, subcollection_name)
-        if not subcollection_key:
-            raise FileNotFoundError(
-                f"{subcollection_name} subcollection not found. "
-                f"Run --init-collection --project \"{self.project_name}\" first."
-            )
-
-        # Get all notes in subcollection
-        notes = self.get_collection_notes(subcollection_key)
-
-        for note in notes:
-            title = self.get_note_title_from_html(note['data']['note'])
-            if note_title in title:
-                content = self.extract_text_from_note_html(note['data']['note'])
-
-                # Check if still template
-                if '[TODO:' in content:
-                    raise ValueError(
-                        f"{note_title} still contains template. "
-                        "Please edit the note in Zotero before building summaries."
-                    )
-
-                # Remove template footer if present
-                if '---' in content:
-                    content = content.split('---')[0]
-
-                # Remove title line
-                lines = content.split('\n')
-                if lines and note_title in lines[0]:
-                    lines = lines[1:]
-
-                # Parse tags (one per line), filter empty lines
-                tags = [line.strip() for line in lines if line.strip() and not line.startswith('Example')]
-
-                if not tags:
-                    raise ValueError(f"{note_title} is empty. Please add tags.")
-
-                return tags
-
-        raise FileNotFoundError(
-            f"{note_title} not found in {subcollection_name} subcollection. "
-            f"Run --init-collection --project \"{self.project_name}\" first."
+        # Load note content using generic method
+        content = self.load_note_from_subcollection(
+            collection_key,
+            note_title,
+            check_todo=True,
+            remove_title_line=True,
+            remove_footer=True,
+            operation_name="building summaries"
         )
+
+        # Parse tags (one per line), filter empty lines
+        lines = content.split('\n')
+        tags = [line.strip() for line in lines if line.strip() and not line.startswith('Example')]
+
+        if not tags:
+            raise ValueError(f"{note_title} is empty. Please add tags.")
+
+        return tags
 
     def has_general_summary(self, item_key: str) -> bool:
         """


### PR DESCRIPTION
Consolidate duplicated note loading logic across zresearcher modules by introducing three new generic methods in ZoteroResearcherBase:

- get_note_from_subcollection(): Find note by title in project subcollection
- load_note_from_subcollection(): Load and clean note content with options
- update_note_in_subcollection(): Update note content with formatting

Benefits:
- Eliminates ~200 lines of duplicated code across modules
- Single source of truth for note operations
- Consistent error messages and behavior
- More maintainable and testable

Changes:
- zr_common.py: Add 3 new generic methods (+146 lines)
- zr_build.py: Refactor load_project_overview/load_tags (-104 lines)
- zr_query.py: Refactor load_research_brief (-47 lines)
- zr_file_search.py: Refactor load_query_request and save state (-89 lines)

All methods maintain backward compatibility with existing behavior.