### PR TITLE
Fix group library support by sanitizing ZOTERO_LIBRARY_TYPE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,7 +544,7 @@ The `ZoteroBaseProcessor` class provides shared functionality for all processors
 ```
 # Zotero Configuration
 ZOTERO_LIBRARY_ID=<library_id>      # User or group ID
-ZOTERO_LIBRARY_TYPE=user|group      # Type of library
+ZOTERO_LIBRARY_TYPE=user|group      # Type of library (user or group - no quotes!)
 ZOTERO_API_KEY=<api_key>            # Zotero API authentication key
 ZOTERO_COLLECTION_KEY=<collection>  # Collection to process
 
@@ -552,6 +552,10 @@ ZOTERO_COLLECTION_KEY=<collection>  # Collection to process
 ANTHROPIC_API_KEY=<api_key>         # Anthropic API key for Claude (required for most features)
 GEMINI_API_KEY=<api_key>            # Google Gemini API key (required for --file-search)
 ```
+
+**Important:** Do not use quotes around values in `.env` files. For example:
+- ✅ Correct: `ZOTERO_LIBRARY_TYPE=group`
+- ❌ Wrong: `ZOTERO_LIBRARY_TYPE='group'` (quotes will be included in the value)
 
 ### Key Dependencies
 - **pyzotero** - Zotero API client

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ All configuration and outputs are stored in Zotero (no external files required).
    ANTHROPIC_API_KEY=your_anthropic_key
    ```
 
+   **Note:** Do not use quotes around values in the `.env` file. For group libraries, use `ZOTERO_LIBRARY_TYPE=group`
+
 3. **Initialize a project:**
    ```bash
    uv run python -m src.zresearcher --init-collection \

--- a/src/analyze_pdfs.py
+++ b/src/analyze_pdfs.py
@@ -462,9 +462,19 @@ def main():
 
     # Get configuration from environment
     library_id = os.getenv('ZOTERO_LIBRARY_ID')
-    library_type = os.getenv('ZOTERO_LIBRARY_TYPE', 'user')
+    library_type_raw = os.getenv('ZOTERO_LIBRARY_TYPE', 'user')
     api_key = os.getenv('ZOTERO_API_KEY')
     collection_key = args.collection or os.getenv('ZOTERO_COLLECTION_KEY')
+
+    # Sanitize library_type: strip quotes and whitespace
+    library_type = library_type_raw.strip().strip("'\"") if library_type_raw else 'user'
+
+    # Validate library_type
+    if library_type not in ['user', 'group']:
+        print(f"Error: Invalid ZOTERO_LIBRARY_TYPE: '{library_type_raw}'")
+        print("Must be either 'user' or 'group' (without quotes in .env file)")
+        print(f"Example .env entry: ZOTERO_LIBRARY_TYPE=group")
+        return
 
     # Validate required configuration
     if not library_id or not api_key:

--- a/src/zotero_diagnose.py
+++ b/src/zotero_diagnose.py
@@ -130,9 +130,19 @@ def main():
     
     # Get configuration
     LIBRARY_ID = os.environ.get('ZOTERO_LIBRARY_ID')
-    LIBRARY_TYPE = os.environ.get('ZOTERO_LIBRARY_TYPE', 'group')
+    LIBRARY_TYPE_RAW = os.environ.get('ZOTERO_LIBRARY_TYPE', 'group')
     API_KEY = os.environ.get('ZOTERO_API_KEY')
-    
+
+    # Sanitize library_type: strip quotes and whitespace
+    LIBRARY_TYPE = LIBRARY_TYPE_RAW.strip().strip("'\"") if LIBRARY_TYPE_RAW else 'group'
+
+    # Validate library_type (unless being overridden by command-line args below)
+    if LIBRARY_TYPE not in ['user', 'group']:
+        print(f"Error: Invalid ZOTERO_LIBRARY_TYPE: '{LIBRARY_TYPE_RAW}'")
+        print("Must be either 'user' or 'group' (without quotes in .env file)")
+        print(f"Example .env entry: ZOTERO_LIBRARY_TYPE=group")
+        return
+
     # Check for command line arguments
     if len(sys.argv) > 1:
         if sys.argv[1] == '--help':

--- a/src/zr_cleanup.py
+++ b/src/zr_cleanup.py
@@ -671,9 +671,18 @@ def main():
 
     # Get required credentials
     library_id = os.getenv('ZOTERO_LIBRARY_ID')
-    library_type = os.getenv('ZOTERO_LIBRARY_TYPE', 'user')
+    library_type_raw = os.getenv('ZOTERO_LIBRARY_TYPE', 'user')
     api_key = os.getenv('ZOTERO_API_KEY')
     anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')
+
+    # Sanitize library_type: strip quotes and whitespace
+    library_type = library_type_raw.strip().strip("'\"") if library_type_raw else 'user'
+
+    # Validate library_type
+    if library_type not in ['user', 'group']:
+        print(f"Error: Invalid ZOTERO_LIBRARY_TYPE: '{library_type_raw}'")
+        print("Must be either 'user' or 'group' (without quotes)")
+        sys.exit(1)
 
     if not all([library_id, api_key, anthropic_api_key]):
         print("Error: Missing required environment variables")

--- a/src/zresearcher.py
+++ b/src/zresearcher.py
@@ -167,11 +167,22 @@ Examples:
 
     # Get configuration from environment
     library_id = os.getenv('ZOTERO_LIBRARY_ID')
-    library_type = os.getenv('ZOTERO_LIBRARY_TYPE', 'user')
+    library_type_raw = os.getenv('ZOTERO_LIBRARY_TYPE', 'user')
     zotero_api_key = os.getenv('ZOTERO_API_KEY')
     anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')
     gemini_api_key = os.getenv('GEMINI_API_KEY')
     collection_key = args.collection or os.getenv('ZOTERO_COLLECTION_KEY')
+
+    # Sanitize library_type: strip quotes and whitespace
+    # (users sometimes add quotes in .env files like ZOTERO_LIBRARY_TYPE='group')
+    library_type = library_type_raw.strip().strip("'\"") if library_type_raw else 'user'
+
+    # Validate library_type
+    if library_type not in ['user', 'group']:
+        print(f"Error: Invalid ZOTERO_LIBRARY_TYPE: '{library_type_raw}'")
+        print("Must be either 'user' or 'group' (without quotes in .env file)")
+        print(f"Example .env entry: ZOTERO_LIBRARY_TYPE=group")
+        return
 
     # Validate required configuration
     if not library_id or not zotero_api_key:


### PR DESCRIPTION
Users were getting 404 errors when using group libraries because quotes in .env files (e.g., ZOTERO_LIBRARY_TYPE='group') were being included in the value, causing pyzotero to construct invalid API URLs.

Changes:
- Add sanitization to strip quotes and whitespace from ZOTERO_LIBRARY_TYPE
- Add validation to ensure library_type is either 'user' or 'group'
- Apply fix across all modules: zresearcher.py, zr_cleanup.py, analyze_pdfs.py, zotero_diagnose.py
- Update documentation (README.md, CLAUDE.md) to clarify .env format
- Add clear error messages when invalid library_type is detected

Fixes issue where API calls used /users/ instead of /groups/ for group libraries.