### PR TITLE
Fix 100-item collection limit by using pyzotero everything() method

### DIFF
--- a/src/analyze_pdfs.py
+++ b/src/analyze_pdfs.py
@@ -94,7 +94,8 @@ class ZoteroPDFAnalyzer:
         """
         print(f"Fetching items from collection {collection_key}...")
         try:
-            items = self.zot.collection_items(collection_key)
+            # Use everything() to handle pagination and fetch all items (no 100-item limit)
+            items = self.zot.everything(self.zot.collection_items(collection_key))
             print(f"Found {len(items)} items in collection")
             return items
         except Exception as e:

--- a/src/zotero_base.py
+++ b/src/zotero_base.py
@@ -509,7 +509,8 @@ class ZoteroBaseProcessor:
             List of note items
         """
         try:
-            items = self.zot.collection_items(collection_key)
+            # Use everything() to handle pagination and fetch all items (no 100-item limit)
+            items = self.zot.everything(self.zot.collection_items(collection_key))
             notes = [item for item in items if item['data']['itemType'] == 'note']
             return notes
         except Exception as e:

--- a/src/zr_common.py
+++ b/src/zr_common.py
@@ -842,7 +842,8 @@ gemini_uploaded_files={}
         # Get items from each target subcollection
         for subcoll_key in target_subcollection_keys:
             try:
-                subcoll_items = self.zot.collection_items_top(subcoll_key)
+                # Use everything() to handle pagination and fetch all items (no 100-item limit)
+                subcoll_items = self.zot.everything(self.zot.collection_items_top(subcoll_key))
                 for item in subcoll_items:
                     item_key = item['key']
                     if item_key not in seen_keys:


### PR DESCRIPTION
The get_collection_items() method was only returning the first 100 items due to Zotero API's default pagination limit. This change wraps the collection_items_top() call with everything() to automatically handle pagination and retrieve all items in the collection.