### PR TITLE
Refactor CLAUDE.md into modular documentation structure

### DIFF
--- a/docs/claude/commands.md
+++ b/docs/claude/commands.md
@@ -1,0 +1,315 @@
+# CLI Commands Reference
+
+Full command reference for ZoteroResearcher. For quick start, see the root [CLAUDE.md](../../CLAUDE.md).
+
+## ZoteroResearcher - Primary Tool
+
+```bash
+# Step 0: List collections
+uv run python -m src.zresearcher --list-collections
+
+# Step 1: Initialize a project in a collection (creates template notes in Zotero)
+uv run python -m src.zresearcher --init-collection \
+    --collection COLLECTION_KEY --project "My Research Project"
+
+# Step 2: List existing projects in a collection
+uv run python -m src.zresearcher --list-projects --collection COLLECTION_KEY
+
+# Step 3: (Optional) Organize sources to ensure all items have acceptable attachments
+uv run python -m src.zresearcher --organize-sources --collection COLLECTION_KEY
+
+# Step 4: Edit the template notes in Zotero (in the 【ZResearcher: PROJECT】 subcollection):
+#   - 【Project Overview: PROJECT】 (describe your research project)
+#   - 【Research Tags: PROJECT】 (one tag per line)
+#   - 【Research Brief: PROJECT】 (your research question)
+#   - 【Project Config: PROJECT】 (optional: tune performance & LLM settings)
+
+# Step 5: Build general summaries (Phase 1 - loads config from Zotero)
+uv run python -m src.zresearcher --build-summaries \
+    --collection COLLECTION_KEY --project "My Research Project"
+
+# Rebuild existing summaries (force mode)
+uv run python -m src.zresearcher --build-summaries \
+    --collection COLLECTION_KEY --project "My Research Project" --force
+
+# Step 6: Run query (Phase 2 - loads brief from Zotero, stores report as note)
+uv run python -m src.zresearcher --query-summary \
+    --collection COLLECTION_KEY --project "My Research Project"
+
+# Verbose mode for detailed logging
+uv run python -m src.zresearcher --query-summary \
+    --collection COLLECTION_KEY --project "My Research Project" --verbose
+```
+
+## File Search (Google Gemini RAG)
+
+```bash
+# Step 1: Upload files to Gemini file search store
+uv run python -m src.zresearcher --upload-files \
+    --collection COLLECTION_KEY --project "My Research Project"
+
+# Force re-upload of all files (deletes existing file search store and re-uploads)
+uv run python -m src.zresearcher --upload-files \
+    --collection COLLECTION_KEY --project "My Research Project" --force
+
+# Step 2: Edit the Query Request note in Zotero (in the 【ZResearcher: PROJECT】 subcollection):
+#   - 【Query Request】 (your File Search query)
+
+# Step 3: Run File Search query (requires files to be uploaded first)
+uv run python -m src.zresearcher --file-search \
+    --collection COLLECTION_KEY --project "My Research Project"
+
+# Verbose mode for detailed logging
+uv run python -m src.zresearcher --file-search \
+    --collection COLLECTION_KEY --project "My Research Project" --verbose
+```
+
+### File Search Implementation Details
+
+- Uses Google Gemini File Search Stores for efficient RAG querying
+- Two-stage workflow: upload files first (--upload-files), then run queries (--file-search)
+- Files are uploaded to a dedicated file search store (not passed in context)
+- Store is used as a tool during generation, avoiding context window limits
+- Supports large collections (tested with 70+ files)
+- Incremental uploads: only new files are uploaded on subsequent --upload-files runs
+- Automatically detects and warns about new files not yet uploaded
+- Automatically extracts and displays grounding sources
+- LLM-generated report titles based on query request (format: "File Search Report: {title}")
+- Store name and upload state tracked in Project Config note
+
+## Subcollection Filtering
+
+All workflows support optional subcollection filtering to process only items in specific subcollections:
+
+```bash
+# Process only items in specific subcollections (comma-separated names)
+uv run python -m src.zresearcher --organize-sources \
+    --collection COLLECTION_KEY --subcollections "Research Papers,Reports"
+
+uv run python -m src.zresearcher --build-summaries \
+    --collection COLLECTION_KEY --project "My Project" \
+    --subcollections "Research Papers,Reports"
+
+uv run python -m src.zresearcher --query-summary \
+    --collection COLLECTION_KEY --project "My Project" \
+    --subcollections "Research Papers"
+
+# Process all subcollections (excludes main collection items)
+uv run python -m src.zresearcher --build-summaries \
+    --collection COLLECTION_KEY --project "My Project" \
+    --subcollections all
+
+# Include main collection items along with subcollections
+uv run python -m src.zresearcher --build-summaries \
+    --collection COLLECTION_KEY --project "My Project" \
+    --subcollections "Research Papers" --include-main
+
+# File Search with subcollection filtering
+uv run python -m src.zresearcher --upload-files \
+    --collection COLLECTION_KEY --project "My Project" \
+    --subcollections "Research Papers,Reports"
+
+uv run python -m src.zresearcher --file-search \
+    --collection COLLECTION_KEY --project "My Project" \
+    --subcollections "Research Papers,Reports"
+```
+
+### Subcollection Filtering Behavior
+
+- **No flags**: Process all items in the main collection (default behavior)
+- **`--subcollections "Name1,Name2"`**: Process only items in specified subcollections
+- **`--subcollections all`**: Process items in all subcollections (excluding the ZResearcher project subcollection)
+- **`--include-main`**: Also include items from the main collection when using `--subcollections`
+- The ZResearcher project subcollection (e.g., `【ZResearcher: My Project】`) is always excluded from filtering
+- Subcollection names are case-sensitive and must match exactly
+- Error is shown if a specified subcollection name doesn't exist, with a list of available subcollections
+
+## Cleanup
+
+```bash
+# Preview cleanup for a specific project (dry-run mode - no changes made)
+uv run python -m src.zresearcher --cleanup-project \
+    --collection COLLECTION_KEY --project "My Research Project" --dry-run
+
+# Clean up a specific project (deletes subcollection and all summary notes)
+uv run python -m src.zresearcher --cleanup-project \
+    --collection COLLECTION_KEY --project "My Research Project"
+
+# Skip confirmation prompt (useful for scripts)
+uv run python -m src.zresearcher --cleanup-project \
+    --collection COLLECTION_KEY --project "My Research Project" --yes
+
+# Preview cleanup for ALL projects in a collection (dry-run mode)
+uv run python -m src.zresearcher --cleanup-collection \
+    --collection COLLECTION_KEY --dry-run
+
+# Clean up ALL projects in a collection (use with caution!)
+uv run python -m src.zresearcher --cleanup-collection \
+    --collection COLLECTION_KEY --yes
+
+# Verbose mode shows detailed error messages
+uv run python -m src.zresearcher --cleanup-project \
+    --collection COLLECTION_KEY --project "My Research Project" --verbose
+```
+
+## Export to NotebookLM
+
+Export collection to NotebookLM format by extracting PDFs, text files, and converting HTML to Markdown:
+
+```bash
+# Export entire collection to NotebookLM format
+uv run python -m src.zresearcher --export-to-notebooklm \
+    --collection COLLECTION_KEY --output-dir ./notebooklm_export
+
+# Export with custom output directory
+uv run python -m src.zresearcher --export-to-notebooklm \
+    --collection COLLECTION_KEY --output-dir ~/Documents/NotebookLM
+
+# Export only specific subcollections
+uv run python -m src.zresearcher --export-to-notebooklm \
+    --collection COLLECTION_KEY --subcollections "Research Papers,Reports" \
+    --output-dir ./notebooklm_export
+
+# Verbose mode for detailed logging
+uv run python -m src.zresearcher --export-to-notebooklm \
+    --collection COLLECTION_KEY --verbose
+```
+
+### Export Behavior
+
+- **PDFs**: Copied as-is to output directory
+- **Text files (.txt)**: Copied as-is to output directory
+- **HTML snapshots**: Converted to Markdown using Trafilatura and saved as .md files
+- Filenames are sanitized and made unique using item titles and attachment keys
+- Supports subcollection filtering (same as other workflows)
+- No project name required (standalone operation)
+- Default output directory: `./notebooklm_export`
+
+### Use Cases
+
+- Prepare sources for NotebookLM analysis without summarization
+- Quick export of all source documents in NotebookLM-compatible format
+- Export specific subcollections for focused analysis
+- Backup source documents in a portable format
+
+## Export Summaries to Markdown
+
+Export all ZResearcher summary notes for a project as either a single consolidated file or separate files:
+
+```bash
+# Export all summary notes to single consolidated file (default: ./zresearcher_summaries_{project}.md)
+uv run python -m src.zresearcher --export-summaries \
+    --collection COLLECTION_KEY --project "My Research Project"
+
+# Export with custom output file path
+uv run python -m src.zresearcher --export-summaries \
+    --collection COLLECTION_KEY --project "My Research Project" \
+    --output-file ./my_summaries.md
+
+# Export as separate .md files in a directory (default: ./zresearcher_summaries_{project}/)
+uv run python -m src.zresearcher --export-summaries \
+    --collection COLLECTION_KEY --project "My Research Project" \
+    --separate-files
+
+# Export as separate files with custom directory path
+uv run python -m src.zresearcher --export-summaries \
+    --collection COLLECTION_KEY --project "My Research Project" \
+    --separate-files --output-file ./summaries_directory
+
+# Export only summaries from specific subcollections
+uv run python -m src.zresearcher --export-summaries \
+    --collection COLLECTION_KEY --project "My Research Project" \
+    --subcollections "Research Papers,Reports"
+
+# Verbose mode for detailed logging
+uv run python -m src.zresearcher --export-summaries \
+    --collection COLLECTION_KEY --project "My Research Project" --verbose
+```
+
+### Export Behavior
+
+- Finds all items in the collection with "【ZResearcher Summary: PROJECT】" notes (created by --build-summaries)
+- Extracts the content from each summary note (Metadata, Tags, Summary sections)
+- **Consolidated mode (default)**: Appends all summaries into a single markdown file with headers for each item
+- **Separate files mode (--separate-files)**: Creates individual .md files for each summary in a directory
+  - Filenames: `001_Item_Title.md`, `002_Item_Title.md`, etc.
+  - Files are numbered and include sanitized item titles
+- Supports subcollection filtering (same as other workflows)
+- Requires project name to identify which summaries to export
+- Default output:
+  - Consolidated: `./zresearcher_summaries_{project}.md`
+  - Separate files: `./zresearcher_summaries_{project}/`
+
+### Use Cases
+
+- **Consolidated file**: Create a single reference document, share with collaborators, archive summaries
+- **Separate files**: Individual review/editing, version control friendly, focused analysis per source
+- Create input for further analysis or LLM processing
+- Generate documents for reading or printing
+
+## Local Cache (Experimental)
+
+Local caching reduces API calls and enables offline operation. Cache is stored in `~/.zotero_summarizer/cache/`.
+
+```bash
+# Sync collection to local cache (downloads items, children, attachments)
+uv run python -m src.zresearcher --sync --collection COLLECTION_KEY
+
+# Force full re-sync (ignore existing cache)
+uv run python -m src.zresearcher --sync --collection COLLECTION_KEY --force
+
+# Check cache status for a collection
+uv run python -m src.zresearcher --cache-status --collection COLLECTION_KEY
+
+# Clear cache for a collection
+uv run python -m src.zresearcher --clear-cache --collection COLLECTION_KEY
+
+# Run workflow offline using cached data (requires prior --sync)
+uv run python -m src.zresearcher --query-summary \
+    --collection COLLECTION_KEY --project "My Project" \
+    --enable-cache --offline
+```
+
+### Cache Features
+
+- **SQLite-based storage**: Metadata, items, children stored in SQLite database per collection
+- **Attachment caching**: PDF, HTML, TXT files downloaded during sync
+- **Subcollection support**: Syncing parent collection includes all subcollections
+- **Delta sync**: On workflow start, checks for changes and syncs incrementally
+- **Offline mode**: `--offline` flag uses only cached data (no API calls)
+- **Write-through**: Write operations update both API and cache
+
+### Cache Location
+
+```
+~/.zotero_summarizer/
+└── cache/
+    ├── {library_id}_{collection_key}.db    # SQLite database
+    └── attachments/
+        ├── {attachment_key}.pdf            # Cached files
+        └── {attachment_key}.html
+```
+
+### Use Cases
+
+- Reduce API calls for frequently-accessed collections
+- Work offline (e.g., on airplane, poor connectivity)
+- Speed up repetitive operations (eliminates redundant API calls)
+- Future: Vector database integration for RAG queries
+
+## Diagnostic Utility
+
+```bash
+# Run diagnostic utility for troubleshooting
+uv run python -m src.zotero_diagnose --user
+uv run python -m src.zotero_diagnose --group GROUP_ID
+```
+
+## Legacy Tools
+
+Legacy tools have been deprecated and moved to `/old/` directory:
+
+```bash
+# extract_html.py and summarize_sources.py have been superseded by zresearcher.py
+# These files are preserved in /old/ for reference only
+```

--- a/docs/claude/content-extraction.md
+++ b/docs/claude/content-extraction.md
@@ -1,0 +1,113 @@
+# Content Extraction
+
+Documentation for content extraction methods used across all ZoteroResearcher tools.
+
+## Content Retrieval Priority
+
+When retrieving content from sources, ZoteroResearcher uses this priority order:
+
+1. **Existing "Markdown Extract" note** (from legacy tools)
+2. **HTML snapshot** (Zotero stored snapshot)
+3. **PDF attachment** (PyMuPDF extraction)
+4. **URL fetch** (for webpage items without snapshots)
+
+---
+
+## Extraction Methods
+
+### Trafilatura Extraction (Default)
+
+The primary extraction method for all web content.
+
+**Characteristics:**
+- Purpose-built for extracting main article content from web pages
+- Intelligently identifies and extracts article content
+- Handles documents of any size
+- Outputs clean markdown directly
+- Free, fast, and accurate for most web pages
+- **Default method for all extractions**
+
+### LLM Polish (`--use-llm`)
+
+Optional enhancement that applies Claude API to improve extraction quality.
+
+**Characteristics:**
+- Applies Claude API to polish Trafilatura output
+- Improves markdown formatting and structure
+- Fixes inconsistencies and artifacts
+- Enhances readability
+- Requires `ANTHROPIC_API_KEY` environment variable
+- Works with content of any size (since it polishes extracted markdown, not raw HTML)
+
+### BeautifulSoup Extraction (Fallback Only)
+
+Used only when Trafilatura fails.
+
+**Characteristics:**
+- Rule-based HTML cleaning
+- Removes script, style, nav, footer, header tags
+- Converts to Markdown using html2text
+- Used only as fallback when Trafilatura fails
+- Can be disabled with `--no-fallback`
+
+---
+
+## HTML Processing Pipelines
+
+### Trafilatura Pipeline (Default)
+
+1. Trafilatura analyzes HTML structure
+2. Identifies main content area using heuristics
+3. Extracts article content (text, headings, links, tables)
+4. Removes ads, navigation, footers, and other non-content
+5. Outputs clean Markdown directly
+6. Handles documents of any size
+
+### Trafilatura + LLM Polish Pipeline (`--use-llm`)
+
+1. Trafilatura extracts main content to Markdown
+2. Send extracted Markdown to Claude API
+3. Claude polishes formatting and structure
+4. Claude fixes any extraction artifacts
+5. Returns enhanced Markdown
+6. Fallback to unpolished Trafilatura output if LLM fails
+
+### BeautifulSoup Pipeline (Fallback Only)
+
+1. Parse HTML with BeautifulSoup
+2. Remove script, style, nav, footer, and header tags
+3. Extract text content
+4. Convert to Markdown using html2text
+5. Used only when Trafilatura fails
+
+---
+
+## PDF Extraction
+
+PDF content is extracted using PyMuPDF (fitz):
+
+- Extracts text content from all pages
+- Preserves basic structure where possible
+- Handled in `zr_common.py` via `extract_text_from_pdf()`
+
+---
+
+## LLM Extractor Module (`src/llm_extractor.py`)
+
+The `LLMExtractor` class provides AI-powered content polishing:
+
+### Methods
+
+- `__init__()` - Initializes Anthropic client with API key and model selection
+- `polish_markdown()` - **PRIMARY** - Polishes Trafilatura-extracted markdown for better formatting
+- `extract_article_markdown()` - Legacy method for direct HTML extraction (kept for compatibility)
+- `preprocess_html()` - Removes scripts, styles, and non-content elements before sending to LLM
+- `set_model()` - Change the Claude model (e.g., claude-haiku-4-5, claude-3-5-sonnet)
+
+### Key Features
+
+- Polishes Trafilatura output for improved formatting and readability
+- Fixes markdown inconsistencies and structural issues
+- Preserves all content and links from original extraction
+- Uses Claude Haiku 4.5 by default for cost efficiency
+- Handles content of any size (works with already-extracted markdown)

--- a/docs/claude/implementation-details.md
+++ b/docs/claude/implementation-details.md
@@ -1,0 +1,77 @@
+# Implementation Details
+
+Edge cases, rate limiting, and important implementation details for ZoteroResearcher.
+
+## API Rate Limiting
+
+The code includes 1-second delays between API calls to respect Zotero's rate limits. This is implemented in the collection processing loop.
+
+## Duplicate Prevention
+
+The `--force` flag controls whether to re-extract markdown notes. The code checks for existing "Markdown Extract" notes to avoid duplicates. This prevents the same content from being extracted multiple times.
+
+## Library Type Support
+
+Supports both user libraries and group libraries. The `ZOTERO_LIBRARY_TYPE` environment variable determines which type is used.
+
+**Important:** Do not use quotes around values in `.env` files:
+- Correct: `ZOTERO_LIBRARY_TYPE=group`
+- Wrong: `ZOTERO_LIBRARY_TYPE='group'` (quotes will be included in the value)
+
+## PDF Attachment Handling
+
+Items with PDF attachments are automatically skipped for HTML extraction. This prevents unnecessary webpage fetching when a PDF version already exists. The logic checks all child attachments for PDF files (by content type or file extension) before attempting any HTML extraction.
+
+## Webpage Without Snapshot Handling
+
+The tool can extract content from webpage items even without HTML snapshots:
+
+- If an item has **no child items** and is a `webpage` type with a URL, content is fetched directly from the URL
+- If an item has **child items but no HTML attachments** (e.g., only text files) and is a `webpage` type, content is fetched from the parent item's URL
+- This enables extraction from webpages added to Zotero without saving snapshots
+- PDF attachments take priority - if a PDF exists, webpage extraction is skipped
+
+## Smart Storage for Large Reports
+
+Reports are stored differently based on size:
+
+- **Reports < 1MB**: Stored as full Zotero notes in the project subcollection
+- **Reports >= 1MB**: Saved as HTML files with a stub note pointing to the file location
+
+This prevents issues with Zotero's note size limits.
+
+## Template Validation
+
+When loading project configuration from Zotero notes:
+
+- The tool checks for `[TODO:` markers in template notes
+- If markers are found, it will refuse to run and prompt you to edit the notes
+- This ensures you don't accidentally run with placeholder templates
+
+## Cleanup Behavior
+
+The cleanup workflow (`--cleanup-project`, `--cleanup-collection`):
+
+- Supports dry-run mode (`--dry-run`) for safe previewing
+- Supports skip-confirmation mode (`--yes`) for scripting
+- Continues cleanup even if individual deletions fail
+- Reports detailed summary of deleted items and errors
+- Deletes child summary notes attached to items
+- Deletes Gemini file search stores (and all files in store)
+
+## Cache Invalidation
+
+When using the local cache (`--enable-cache`):
+
+- Write operations update both API and cache (write-through)
+- Delta sync checks for changes and syncs incrementally
+- Cache can be cleared per-collection with `--clear-cache`
+- Offline mode (`--offline`) uses only cached data
+
+## Subcollection Filtering
+
+When using `--subcollections`:
+
+- The ZResearcher project subcollection is always excluded from filtering
+- Subcollection names are case-sensitive and must match exactly
+- Error is shown if a specified subcollection name doesn't exist

--- a/docs/claude/workflows.md
+++ b/docs/claude/workflows.md
@@ -1,0 +1,269 @@
+# ZoteroResearcher Workflows
+
+Detailed workflow documentation for ZoteroResearcher. For CLI commands, see [commands.md](commands.md).
+
+## Two-Phase Workflow Overview
+
+ZoteroResearcher uses a **two-phase workflow** with **project-based organization**:
+
+### Phase 1 - Build Summaries (`--build-summaries`)
+
+- Pre-process all sources with project-aware summaries
+- Extract metadata (authors, date, publication, type, URL)
+- Generate context-aware summaries informed by project overview
+- Assign relevant tags from user-provided list
+- Create structured "General Summary" notes in Zotero
+- Run once per project, reuse across multiple queries
+- Uses parallel LLM processing for efficiency
+
+### Phase 2 - Query (`--query-summary`)
+
+- Load research brief from Zotero notes
+- Parse pre-built summaries with metadata and tags
+- Evaluate relevance using metadata + tags + summary content (parallel processing)
+- Rank sources by relevance score
+- Generate detailed targeted summaries for relevant sources (parallel processing)
+- Output professional HTML report
+- Smart storage: reports <1MB as notes, >1MB as files with stub notes
+
+### Phase 3 - Research Synthesis (automatic after Phase 2)
+
+- Automatically triggered after creating research report (can be disabled in config)
+- Loads project overview and research brief from Zotero notes
+- Analyzes the full research report to create a meta-analysis synthesis
+- Uses Claude Sonnet (always, regardless of use_sonnet setting) for high-quality analysis
+- Generates comprehensive synthesis including:
+  - Executive Summary
+  - Main Themes and Patterns
+  - Key Findings (with source citations)
+  - Implications and Insights
+  - Recommendations
+  - Research Gaps and Future Directions
+- Saves as "Research Synthesis: {title}" note in project subcollection
+- Can be disabled by setting `generate_synthesis=false` in Project Config
+
+## Key Features
+
+- Project-based organization (multiple projects per collection)
+- Two-phase workflow: build once, query multiple times
+- Context-aware summaries informed by project overview
+- Tag-based categorization from user-defined taxonomy
+- Rich metadata extraction from Zotero API
+- Relevance evaluation using metadata + tags + summary
+- Professional HTML reports with metadata and tag badges
+- Parallel LLM processing for speed and efficiency
+- Cost-efficient: expensive summarization separate from cheap relevance checks
+
+## LLM Model Strategy
+
+- **Claude Haiku 4.5** for Phase 1 general summaries (cost-efficient)
+- **Claude Haiku 4.5** for relevance evaluation (fast, cheap)
+- **Claude Haiku 4.5** for detailed targeted summaries by default (cost-efficient)
+- **Claude Sonnet 4.5** for detailed targeted summaries with Project Config override (production quality)
+- **Claude Sonnet 4.5** for research synthesis (always, high-quality meta-analysis)
+
+## Benefits of Two-Phase Approach
+
+- **Efficiency**: Build summaries once, query many times
+- **Context-Aware**: Summaries informed by project overview
+- **Better Relevance**: Tags help LLM evaluate topical alignment
+- **Metadata Rich**: Display source provenance and authority
+- **Flexibility**: Run multiple queries against same summary set
+- **Cost Optimization**: ~90% cost reduction by separating phases
+
+---
+
+## Zotero-Native Workflow (Project-Based)
+
+### Initialization (run once per project)
+
+1. Run `--init-collection --collection KEY --project "PROJECT_NAME"`
+2. Creates project-specific subcollection: `【ZResearcher: PROJECT_NAME】`
+3. Creates four template notes in the subcollection:
+   - **【Project Overview: PROJECT_NAME】**: Describe research project and goals
+   - **【Research Tags: PROJECT_NAME】**: Tag list (one per line)
+   - **【Research Brief: PROJECT_NAME】**: Research question/brief
+   - **【Project Config: PROJECT_NAME】**: Optional performance & LLM tuning
+4. Edit template notes in Zotero (remove [TODO: markers)
+
+### Phase 1 - Build Summaries
+
+1. Run `--build-summaries --collection KEY --project "PROJECT_NAME"`
+2. Load project overview, tags, and config from Zotero notes
+3. For each source in collection:
+   - Extract metadata from Zotero API
+   - Get source content (HTML/PDF/URL)
+   - Generate context-aware summary with LLM (parallel processing)
+   - Assign relevant tags from provided list
+   - Identify document type (LLM)
+   - Create structured "General Summary" note in Zotero
+4. Skip existing summaries unless `--force` flag used
+
+### Phase 2 - Query Summary
+
+1. Run `--query-summary --collection KEY --project "PROJECT_NAME"`
+2. Load research brief and config from Zotero notes
+3. For each source in collection:
+   - Load and parse "General Summary" note
+   - Extract metadata, tags, and summary
+   - Evaluate relevance using metadata + tags + summary (parallel processing)
+   - If score ≥ threshold: add to relevant sources list
+4. Rank relevant sources by score
+5. Generate detailed targeted summaries with quotes (parallel processing)
+6. Generate HTML report with LLM-generated title
+7. **Smart storage:**
+   - If report <1MB: Create full note in project subcollection
+   - If report >1MB: Save as HTML file + create stub note with file location
+
+### Phase 3 - Research Synthesis (automatic)
+
+1. After research report is created (if `generate_synthesis=true` in config)
+2. Load project overview from Zotero notes
+3. Send report + project overview + research brief to Claude Sonnet
+4. Generate comprehensive meta-analysis synthesis
+5. Save as "Research Synthesis: {title}" note in project subcollection
+
+---
+
+## Data Flow Details
+
+### Initialization
+
+1. Load Zotero credentials and LLM API key from environment variables
+2. Validate project name and collection key
+3. Route to appropriate workflow module (Init/Build/Query)
+
+### Phase 1 - Build Summaries Data Flow
+
+1. Load project overview, tags, and config from Zotero subcollection notes
+2. For each item in collection:
+   - Skip if already a note/attachment
+   - Check for existing project-specific summary (skip unless `--force`)
+   - Extract metadata from Zotero API
+   - Get source content using priority: Markdown Extract → HTML → PDF → URL
+   - Build batch of LLM requests
+3. Process batch in parallel with configured worker count
+4. Create structured "General Summary" notes in Zotero with metadata, tags, and summary
+
+### Phase 2 - Query Summary Data Flow
+
+1. Load research brief and config from Zotero subcollection notes
+2. For each item in collection:
+   - Load and parse existing "General Summary" note
+   - Extract metadata, tags, and summary
+   - Build batch of relevance evaluation requests
+3. Process relevance evaluations in parallel
+4. Filter sources by relevance threshold
+5. Rank sources by relevance score
+6. Build batch of targeted summary requests for relevant sources
+7. Process targeted summaries in parallel
+8. Generate HTML report with LLM-generated title
+9. Smart storage: Save as note if <1MB, otherwise save as file with stub note
+
+### Phase 3 - Research Synthesis Data Flow
+
+1. Check if synthesis is enabled (`generate_synthesis=true` in config, default: enabled)
+2. Load project overview from Zotero notes
+3. Generate synthesis prompt with:
+   - Project overview
+   - Research brief
+   - Full research report HTML content (truncated to 400K chars if needed)
+4. Call Claude Sonnet with synthesis prompt (16K max tokens)
+5. Create "Research Synthesis: {title}" note in project subcollection
+
+---
+
+## Structured Note Format
+
+General summaries are stored in Zotero with this structure:
+
+```
+General Summary
+
+## Metadata
+- **Title**: <title>
+- **Authors**: <authors>
+- **Date**: <date>
+- **Publication**: <publication>
+- **Type**: <document type determined by LLM>
+- **URL**: <url>
+
+## Tags
+<comma-separated tags>
+
+## Summary
+<summary text>
+
+---
+Created: <timestamp>
+Project: <project name>
+```
+
+---
+
+## Template Notes
+
+The `--init-collection` command creates a "ZoteroResearcher" subcollection with template notes:
+
+### 1. Project Overview Template
+
+```
+[TODO: Replace this template with your project description]
+
+Describe your research project, goals, and key areas of interest.
+This context will inform the general summaries created for each source.
+
+Example:
+This project examines the impact of artificial intelligence on
+software development practices. Key areas include: code generation
+tools, automated testing, productivity metrics, and ethical
+considerations. The research will inform a technical report for
+software engineering managers.
+
+---
+Template created by ZoteroResearcher
+Edit this note before running --build-summaries
+```
+
+### 2. Research Tags Template
+
+```
+[TODO: Replace with your research tags, one per line]
+
+Example tags:
+artificial-intelligence
+software-development
+code-generation
+automated-testing
+productivity-metrics
+ethics
+
+---
+Template created by ZoteroResearcher
+Edit this note before running --build-summaries
+```
+
+### 3. Research Brief Template
+
+```
+[TODO: Replace this template with your research question]
+
+Describe the specific research question or brief you want to answer.
+This will be used to evaluate relevance of sources and generate targeted summaries.
+
+Example:
+What are the current challenges and best practices for integrating
+AI-powered code generation tools into enterprise software development
+workflows? Focus on adoption barriers, productivity impacts, and
+quality assurance approaches.
+
+---
+Template created by ZoteroResearcher
+Edit this note before running --query-summary
+```
+
+### Template Validation
+
+- The tool checks for `[TODO:` markers when loading configuration
+- If markers are found, it will refuse to run and prompt you to edit the notes
+- This ensures you don't accidentally run with placeholder templates

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,244 @@
+# Source Module Architecture
+
+Detailed module responsibilities and APIs for the ZoteroResearcher codebase.
+
+## File Structure
+
+```
+src/
+├── zresearcher.py          # CLI entry point & routing
+├── zr_common.py            # Base class & shared utilities
+├── zr_init.py              # Collection initialization workflow
+├── zr_organize_sources.py  # Source organization workflow
+├── zr_build.py             # Phase 1: Build summaries workflow
+├── zr_query.py             # Phase 2: Query & report generation workflow
+├── zr_file_search.py       # File Search: Gemini RAG integration
+├── zr_cleanup.py           # Cleanup: Delete projects & summary notes
+├── zr_export.py            # Export: NotebookLM format & summary export
+├── zr_llm_client.py        # Centralized LLM API client
+├── zr_prompts.py           # Prompt templates
+├── zotero_base.py          # Base Zotero API functionality
+├── zotero_cache.py         # Local SQLite cache layer
+├── llm_extractor.py        # LLM-powered content polishing
+└── zotero_diagnose.py      # Diagnostic utility
+```
+
+---
+
+## Module Responsibilities
+
+### `zresearcher.py` - CLI Entry Point
+
+- Command-line argument parsing
+- Environment variable loading and validation
+- Routes to appropriate workflow classes
+- No business logic - pure orchestration
+
+### `zr_common.py` - Base Class & Shared Utilities
+
+`ZoteroResearcherBase` class (inherits from `ZoteroBaseProcessor`):
+- Initialization & configuration management
+- `extract_metadata()` - Extract metadata from Zotero API
+- `get_source_content()` - Unified content retrieval (HTML/PDF/URL priority)
+- `extract_text_from_html()` - Trafilatura-based HTML extraction
+- `extract_text_from_pdf()` - PyMuPDF-based PDF extraction
+- `load_project_config_from_zotero()` - Load config from Zotero notes
+- `apply_project_config()` - Apply and validate configuration
+- All `_get_*_note_title()` helper methods
+
+Utility function:
+- `validate_project_name()` - Utility function for name validation
+
+### `zr_init.py` - Collection Initialization
+
+`ZoteroResearcherInit` class (inherits from `ZoteroResearcherBase`):
+- `init_collection()` - Create project subcollection & template notes
+- `list_projects()` - List existing projects in a collection
+
+### `zr_organize_sources.py` - Source Organization
+
+`ZoteroResearcherOrganizer` class (inherits from `ZoteroResearcherBase`):
+- `organize_sources()` - Ensure all items have acceptable attachments (HTML/PDF/TXT)
+- `is_txt_attachment()` - Check if attachment is a text file
+- `has_acceptable_attachment()` - Verify item has processable attachment
+- `promote_attachment_to_parent()` - Convert standalone attachments to proper items
+- `save_webpage_snapshot()` - Fetch and save webpage HTML snapshots
+
+Run after `init_collection` but before `build_summaries`.
+
+### `zr_build.py` - Phase 1 Workflow
+
+`ZoteroResearcherBuilder` class (inherits from `ZoteroResearcherBase`):
+- `build_general_summaries()` - Main Phase 1 orchestration with parallel LLM processing
+- `load_project_overview_from_zotero()` - Load project context
+- `load_tags_from_zotero()` - Load tag taxonomy
+- `has_general_summary()` - Check for existing summaries
+- `format_general_summary_note()` - Create structured note format
+
+### `zr_query.py` - Phase 2 Workflow
+
+`ZoteroResearcherQuerier` class (inherits from `ZoteroResearcherBase`):
+- `run_query_summary()` - Main Phase 2 orchestration with parallel processing
+- `load_research_brief_from_zotero()` - Load research question
+- `parse_general_summary_note()` - Parse structured summaries
+- `rank_sources()` - Sort by relevance score
+- `generate_report_title()` - LLM-generated report titles
+- `_compile_research_html_string()` - HTML report generation
+- Smart storage: Notes <1MB, files >1MB with stub notes
+
+### `zr_file_search.py` - File Search Workflow (Gemini RAG)
+
+`ZoteroFileSearcher` class (inherits from `ZoteroResearcherBase`):
+
+**Stage 1: Upload Files (`upload_files_to_gemini()`)**
+- Upload collection files to Gemini file search store
+- Create or reuse existing file search store
+- Support incremental uploads (only new files uploaded)
+- Track uploaded files in Project Config note
+- Support force rebuild (delete and recreate store)
+
+**Stage 2: Query (`run_file_search()`)**
+- Verify files have been uploaded (error if not)
+- Warn about new files not yet uploaded
+- Query Gemini File Search and save results
+- Generate LLM-based report title from query request
+- Create File Search Report notes with grounding sources
+
+**Helper Methods:**
+- `load_query_request_from_zotero()` - Load query from Zotero note
+- `generate_report_title()` - Generate LLM-based title from query request
+- `_load_gemini_state_from_config()` - Load store name and upload state
+- `_save_gemini_state_to_config()` - Save store name and upload state
+
+Uses Google Gemini File Search Stores (genai.Client API). Files uploaded to dedicated store, used as tool (not in context window).
+
+### `zr_cleanup.py` - Cleanup Workflow
+
+`ZoteroResearcherCleaner` class (inherits from `ZoteroResearcherBase`):
+- `cleanup_project()` - Delete specific project subcollection and summary notes
+- `cleanup_all_projects()` - Delete ALL ZResearcher data in collection
+- `is_general_summary_note()` - Identify general summary notes (with optional project filter)
+- `find_general_summary_notes_for_project()` - Find summaries for specific project
+- `find_all_general_summary_notes()` - Find all summary notes in collection
+- `find_all_project_subcollections()` - Find all ZResearcher subcollections
+- `delete_gemini_files_for_project()` - Delete Gemini file search store for project
+- `count_items_in_collection()` - Count items by type (notes/files/items)
+- `preview_cleanup()` - Display preview of what will be deleted
+- `confirm_cleanup()` - Ask user for confirmation
+- `delete_collection_recursive()` - Delete collection and all contents
+
+### `zr_export.py` - Export Workflow
+
+`ZoteroNotebookLMExporter` class (inherits from `ZoteroResearcherBase`):
+
+**NotebookLM Export:**
+- `export_to_notebooklm()` - Main export orchestration with progress tracking
+- `_sanitize_filename()` - Clean filenames for filesystem safety
+- `_get_export_filename()` - Generate unique filenames
+- `_export_pdf_attachment()` - Copy PDF files to output directory
+- `_export_txt_attachment()` - Copy text files to output directory
+- `_export_html_attachment()` - Convert HTML to Markdown and save
+
+**Summary Export:**
+- `export_summaries_to_markdown()` - Export all summary notes (consolidated or separate)
+
+---
+
+## Base Modules
+
+### `zotero_base.py` - Base Zotero API
+
+`ZoteroBaseProcessor` class provides shared functionality:
+
+**Collection & Item Management:**
+- `list_collections()` / `print_collections()` - Collection management
+- `get_collection_items()` - Retrieves top-level items from collection
+- `get_item_attachments()` - Fetches child attachments
+- `get_subcollection()` - Get subcollection by name within parent
+- `create_subcollection()` - Create subcollection inside parent
+
+**Attachment & Content:**
+- `is_html_attachment()` / `is_pdf_attachment()` - Content type detection
+- `download_attachment()` - Downloads attachment content from Zotero
+
+**Note Management:**
+- `create_note()` - Creates child note attached to item (with markdown conversion)
+- `create_standalone_note()` - Creates standalone note in collection
+- `get_collection_notes()` - Get all standalone notes in collection
+- `has_note_with_prefix()` / `get_note_with_prefix()` - Note checking and retrieval
+- `get_note_title_from_html()` - Extract title from note HTML
+- `extract_text_from_note_html()` - Extract plain text from note HTML
+- `markdown_to_html()` - Convert markdown to HTML for Zotero notes
+
+### `zotero_cache.py` - Local SQLite Cache
+
+`ZoteroCache` class provides local caching:
+
+**Storage:**
+- SQLite database per library+collection: `{library_id}_{collection_key}.db`
+- Attachment files in: `~/.zotero_summarizer/cache/attachments/`
+- In-memory session cache for frequently accessed data
+
+**Read Operations (cache-first):**
+- `get_collections()` / `get_collection()` / `get_subcollections()`
+- `get_collection_items()` - Items in a collection
+- `get_item_children()` - Notes and attachments for an item
+- `get_attachment_file()` - Attachment file content
+
+**Write Operations (store after API success):**
+- `store_collection()` / `store_collections()`
+- `store_item()` / `store_items()` - Cache items with collection membership
+- `store_child()` / `store_children()` - Cache notes and attachments
+- `store_attachment_file()` - Cache attachment file content
+
+**Sync State:**
+- `get_library_version()` / `set_library_version()`
+- `is_synced()` / `needs_sync()`
+- `get_last_sync_time()` / `set_last_sync_time()`
+
+**Invalidation:**
+- `invalidate_item()` - Remove item and its children
+- `invalidate_child()` - Remove specific child
+- `invalidate_children_for_parent()` - Remove all children for a parent
+- `clear_all()` - Clear entire cache
+
+**Statistics:**
+- `get_stats()` - Get cache statistics
+- `print_stats()` - Print formatted cache status
+
+---
+
+## Utility Modules
+
+### `zotero_diagnose.py`
+
+Diagnostic tool for troubleshooting Zotero connections and library access. Provides CLI for testing API connectivity and group membership.
+
+### `llm_extractor.py`
+
+See [content-extraction.md](../docs/claude/content-extraction.md) for details.
+
+---
+
+## Legacy Modules (Deprecated)
+
+Located in `/old/` directory:
+
+- **`old/extract_html.py`** - Simple HTML-to-Markdown extraction (superseded by ZoteroResearcher)
+- **`old/summarize_sources.py`** - Basic source summarization (superseded by ZoteroResearcher)
+
+---
+
+## Class Hierarchy
+
+```
+ZoteroBaseProcessor (zotero_base.py)
+└── ZoteroResearcherBase (zr_common.py)
+    ├── ZoteroResearcherInit (zr_init.py)
+    ├── ZoteroResearcherOrganizer (zr_organize_sources.py)
+    ├── ZoteroResearcherBuilder (zr_build.py)
+    ├── ZoteroResearcherQuerier (zr_query.py)
+    ├── ZoteroFileSearcher (zr_file_search.py)
+    ├── ZoteroResearcherCleaner (zr_cleanup.py)
+    └── ZoteroNotebookLMExporter (zr_export.py)
+```


### PR DESCRIPTION
## Summary

Split the monolithic 947-line CLAUDE.md into a modular structure to reduce always-loaded context while preserving all information and improving maintainability.

## Changes

**Root CLAUDE.md (150 lines, 84% reduction)**
- Project overview and quick start
- File structure and key dependencies
- Global invariants (package manager, Python version, LLM strategy)
- Index with links to detailed documentation

**New Documentation Files**
- `docs/claude/commands.md` - Full CLI command reference with examples
- `docs/claude/workflows.md` - Phase 1/2/3 workflow details and data flow diagrams
- `docs/claude/content-extraction.md` - Trafilatura, PDF, URL extraction pipelines
- `docs/claude/implementation-details.md` - Edge cases, rate limiting, gotchas
- `src/CLAUDE.md` - Detailed module architecture and API documentation

## Benefits

1. **Reduced Context Load**: Root file is now 150 lines vs 947 lines
2. **Better Organization**: Related content grouped logically
3. **Easier Maintenance**: Changes can be made to specific sections without touching the entire file
4. **Improved Discoverability**: Clear index with cross-links between documents
5. **Preserved Information**: All content maintained, just reorganized

## Testing

- Verified all content is preserved
- Checked cross-references are correct
- Validated markdown formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)