### PR TITLE
Add source_type field to Phase 1 summaries

### DIFF
--- a/src/zr_export.py
+++ b/src/zr_export.py
@@ -641,6 +641,8 @@ class ZoteroNotebookLMExporter(ZoteroResearcherBase):
             Dict with extracted fields (with defaults for missing/old format notes)
         """
         result = {
+            # Source type
+            'source_type': 'other',
             # Classification
             'research_type': 'unknown',
             'project_role': 'supporting',
@@ -660,6 +662,11 @@ class ZoteroNotebookLMExporter(ZoteroResearcherBase):
             # Tags (from summary)
             'tags': []
         }
+
+        # Parse Source Type - handle hyphenated values like "primary-source", "blog-opinion"
+        source_type_match = re.search(r'(?:\*\*)?Source Type(?:\*\*)?:\s*([\w-]+)', summary_content, re.IGNORECASE)
+        if source_type_match:
+            result['source_type'] = source_type_match.group(1).lower()
 
         # Parse Classification section - handle both plain and markdown formats
         # Plain: "Research Type: review" or Markdown: "**Research Type**: review"
@@ -1202,6 +1209,7 @@ collection: {collection_name}
                 'url': item_data.get('url', ''),
                 'zotero_link': f"zotero://select/items/{item_key}",
                 'item_type': item_data.get('itemType', 'unknown'),
+                'source_type': parsed_summary['source_type'],
                 'tags': tags,
                 'summary_file': None,  # Will be filled in
                 'content_file': None,  # Will be filled in if include_full_content

--- a/src/zr_prompts.py
+++ b/src/zr_prompts.py
@@ -97,6 +97,16 @@ TAGS:
 DOCUMENT_TYPE:
 <specific document type: e.g., journal article, government report, news article, white paper, blog post, speech transcript, dataset documentation, book chapter, etc.>
 
+SOURCE_TYPE:
+<exactly one of: report | article | primary-source | interview | LLM-generated | blog-opinion | other>
+- report: Policy reports, white papers, technical reports, organizational publications
+- article: Journal articles, news articles, magazine pieces
+- primary-source: Original documents, speeches, raw data, official statements, legislation
+- interview: Interview transcripts, Q&A sessions
+- LLM-generated: AI-generated content, chatbot outputs
+- blog-opinion: Blog posts, op-eds, opinion pieces, commentary
+- other: Sources that don't fit above categories
+
 RESEARCH_TYPE:
 <exactly one of: empirical | theoretical | review | primary_source | commentary>
 - empirical: Original data collection/analysis (surveys, experiments, case studies)

--- a/src/zr_query.py
+++ b/src/zr_query.py
@@ -70,6 +70,7 @@ class ZoteroResearcherQuerier(ZoteroResearcherBase):
                 'tags': [],
                 'summary': '',
                 # Enhanced fields (with defaults for old format notes)
+                'source_type': 'other',
                 'research_type': 'unknown',
                 'project_role': 'supporting',
                 'temporal_status': 'current',
@@ -116,6 +117,11 @@ class ZoteroResearcherQuerier(ZoteroResearcherBase):
 
                     result['metadata']['type'] = re.search(r'(?:\*\*)?Type(?:\*\*)?:?\s*(.+?)(?:\n|$)', metadata_section)
                     result['metadata']['type'] = result['metadata']['type'].group(1).strip() if result['metadata']['type'] else ''
+
+                    # Parse Source Type (handle hyphenated values like "primary-source")
+                    source_type_match = re.search(r'(?:\*\*)?Source Type(?:\*\*)?:?\s*([\w-]+)', metadata_section)
+                    if source_type_match:
+                        result['source_type'] = source_type_match.group(1).lower()
 
                     result['metadata']['url'] = re.search(r'(?:\*\*)?URL(?:\*\*)?:?\s*(.+?)(?:\n|$)', metadata_section)
                     result['metadata']['url'] = result['metadata']['url'].group(1).strip() if result['metadata']['url'] else ''


### PR DESCRIPTION
## Summary

Adds a new `source_type` classification field to Phase 1 summaries with controlled vocabulary:

| Value | Description |
|-------|-------------|
| `report` | Policy reports, white papers, technical reports |
| `article` | Journal articles, news articles, magazine pieces |
| `primary-source` | Original documents, speeches, legislation |
| `interview` | Interview transcripts, Q&A sessions |
| `LLM-generated` | AI-generated content |
| `blog-opinion` | Blog posts, op-eds, commentary |
| `other` | Sources that don't fit above categories |

## Changes

| File | Changes |
|------|---------|
| `src/zr_prompts.py` | Add SOURCE_TYPE to prompt output format with category descriptions |
| `src/zr_build.py` | Parse and validate source_type, add to note format |
| `src/zr_export.py` | Parse source_type from notes, add to `citation_index.json` |
| `src/zr_query.py` | Parse source_type for Phase 2 compatibility |

## Backward Compatibility

- Old summaries without source_type default to `'other'`
- No breaking changes to existing workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)